### PR TITLE
Allow concurrent execution of zap on the same Jenkins node

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapDriver.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriver.java
@@ -42,7 +42,7 @@ public interface ZapDriver {
 
     void setZapPort(int zapPort);
 
-    void setZapDir(String dir);
+    void setZapDir(FilePath dir);
 
     void setFailBuild(int all, int hihg, int med, int low);
 
@@ -54,7 +54,7 @@ public interface ZapDriver {
 
     int getZapPort();
 
-    String getZapDir();
+    FilePath getZapDir();
 
     HashMap<Integer, Integer> getFailBuild();
 

--- a/src/main/java/com/vrondakis/zap/ZapDriver.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriver.java
@@ -42,6 +42,8 @@ public interface ZapDriver {
 
     void setZapPort(int zapPort);
 
+    void setZapDir(String dir);
+
     void setFailBuild(int all, int hihg, int med, int low);
 
     void setZapTimeout(int timeout);
@@ -51,6 +53,8 @@ public interface ZapDriver {
     int getZapTimeout();
 
     int getZapPort();
+
+    String getZapDir();
 
     HashMap<Integer, Integer> getFailBuild();
 

--- a/src/main/java/com/vrondakis/zap/ZapDriverController.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverController.java
@@ -17,6 +17,7 @@ public class ZapDriverController {
     static final String CMD_DAEMON = "-daemon";
     static final String CMD_HOST = "-host";
     static final String CMD_PORT = "-port";
+    static final String CMD_DIR = "-dir";
     static final String CMD_CONFIG = "-config";
     static final String CMD_DISABLEKEY = "api.disablekey=true";
     static final String CMD_REGEX = "api.addrs.addr.regex=true";

--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -32,7 +32,7 @@ import net.sf.json.JSONObject;
 public class ZapDriverImpl implements ZapDriver {
     private String zapHost;
     private int zapPort;
-    private String zapDir;
+    private FilePath zapDir;
     private int zapTimeout;
     private HashMap<Integer, Integer> failBuild = new HashMap<>();
     private List<String> allowedHosts = new ArrayList<>();
@@ -355,7 +355,7 @@ public class ZapDriverImpl implements ZapDriver {
 
         if (zapDir != null) {
             cmd.add(ZapDriverController.CMD_DIR);
-            cmd.add(zapDir);
+            cmd.add(zapDir.getRemote());
         }
 
         cmd.add(ZapDriverController.CMD_CONFIG);
@@ -371,7 +371,7 @@ public class ZapDriverImpl implements ZapDriver {
         cmd.add(ZapDriverController.CMD_TIMEOUT);
 
         try {
-            launcher.launch().cmds(cmd).pwd(ws).start();
+            launcher.launch().stdout(launcher.getListener().getLogger()).stderr(launcher.getListener().getLogger()).cmds(cmd).pwd(ws).start();
             launcher.getListener().getLogger().println("zap: Started successfully");
             return true;
         } catch (Exception e) {
@@ -424,7 +424,7 @@ public class ZapDriverImpl implements ZapDriver {
     }
 
     @Override
-    public void setZapDir(String dir) {
+    public void setZapDir(FilePath dir) {
         zapDir = dir;
     }
 
@@ -452,7 +452,7 @@ public class ZapDriverImpl implements ZapDriver {
     }
 
     @Override
-    public String getZapDir() {
+    public FilePath getZapDir() {
         return zapDir;
     }
 

--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -32,6 +32,7 @@ import net.sf.json.JSONObject;
 public class ZapDriverImpl implements ZapDriver {
     private String zapHost;
     private int zapPort;
+    private String zapDir;
     private int zapTimeout;
     private HashMap<Integer, Integer> failBuild = new HashMap<>();
     private List<String> allowedHosts = new ArrayList<>();
@@ -352,6 +353,11 @@ public class ZapDriverImpl implements ZapDriver {
         cmd.add(ZapDriverController.CMD_PORT);
         cmd.add(Integer.toString(zapPort));
 
+        if (zapDir != null) {
+            cmd.add(ZapDriverController.CMD_DIR);
+            cmd.add(zapDir);
+        }
+
         cmd.add(ZapDriverController.CMD_CONFIG);
         cmd.add(ZapDriverController.CMD_DISABLEKEY);
 
@@ -417,6 +423,11 @@ public class ZapDriverImpl implements ZapDriver {
         this.zapPort = zapPort;
     }
 
+    @Override
+    public void setZapDir(String dir) {
+        zapDir = dir;
+    }
+
     public void setFailBuild(int all, int high, int med, int low) {
         failBuild.put(ZapArchive.ALL_ALERT, all);
         failBuild.put(ZapArchive.HIGH_ALERT, high);
@@ -438,6 +449,11 @@ public class ZapDriverImpl implements ZapDriver {
 
     public int getZapPort() {
         return zapPort;
+    }
+
+    @Override
+    public String getZapDir() {
+        return zapDir;
     }
 
     public HashMap<Integer, Integer> getFailBuild() {

--- a/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
@@ -1,6 +1,7 @@
 package com.vrondakis.zap.workflow;
 
 import com.vrondakis.zap.ZapFailBuildAction;
+import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import com.vrondakis.zap.ZapArchive;
@@ -9,6 +10,7 @@ import com.vrondakis.zap.ZapDriverController;
 
 import hudson.model.Result;
 
+import java.io.File;
 import java.time.OffsetDateTime;
 import java.util.concurrent.TimeUnit;
 
@@ -70,6 +72,12 @@ public class ArchiveZapExecution extends DefaultStepExecutionImpl {
 
         } finally {
             boolean success = ZapDriverController.shutdownZap(this.run);
+
+            String zapDir = ZapDriverController.getZapDriver(this.run).getZapDir();
+            if (zapDir != null) {
+                FileUtils.deleteQuietly(new File(zapDir));
+            }
+
             if (!success)
                 listener.getLogger().println("zap: Failed to shutdown ZAP (it's not running?)");
         }

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
@@ -1,9 +1,11 @@
 package com.vrondakis.zap.workflow;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.time.OffsetDateTime;
 import java.util.concurrent.TimeUnit;
 
@@ -67,9 +69,18 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
             return false;
         }
 
+        // create a temp folder where zap will write
+        File zapDir = null;
+        try {
+            zapDir = Files.createTempDirectory("zaptemp").toFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         ZapDriver zapDriver = ZapDriverController.newDriver(this.run);
         // Set ZAP properties
         zapDriver.setZapHost(zapStepParameters.getHost());
+        zapDriver.setZapDir(zapDir.getAbsolutePath());
         zapDriver.setZapPort(zapStepParameters.getPort());
         zapDriver.setZapTimeout(zapStepParameters.getTimeout());
         zapDriver.setAllowedHosts(zapStepParameters.getAllowedHosts());

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.time.OffsetDateTime;
 import java.util.concurrent.TimeUnit;
 
+import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import com.vrondakis.zap.ZapDriver;
 import com.vrondakis.zap.ZapDriverController;
@@ -70,17 +71,17 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
         }
 
         // create a temp folder where zap will write
-        File zapDir = null;
+        FilePath zapDir = null;
         try {
-            zapDir = Files.createTempDirectory("zaptemp").toFile();
-        } catch (IOException e) {
+            zapDir = workspace.createTempDir( "zaptemp", "");
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
 
         ZapDriver zapDriver = ZapDriverController.newDriver(this.run);
         // Set ZAP properties
         zapDriver.setZapHost(zapStepParameters.getHost());
-        zapDriver.setZapDir(zapDir.getAbsolutePath());
+        zapDriver.setZapDir(zapDir);
         zapDriver.setZapPort(zapStepParameters.getPort());
         zapDriver.setZapTimeout(zapStepParameters.getTimeout());
         zapDriver.setAllowedHosts(zapStepParameters.getAllowedHosts());

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
@@ -27,7 +27,7 @@ public class StartZapStep extends Step {
      */
     @DataBoundConstructor
     public StartZapStep(@CheckForNull String host, int port, int timeout, String zapHome, List<String> allowedHosts,
-                        String sessionPath) {
+                        String sessionPath, String zapDir) {
         zapStepParameters = new StartZapStepParameters(host, port, timeout, zapHome, allowedHosts, sessionPath);
     }
 

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
@@ -27,7 +27,7 @@ public class StartZapStep extends Step {
      */
     @DataBoundConstructor
     public StartZapStep(@CheckForNull String host, int port, int timeout, String zapHome, List<String> allowedHosts,
-                        String sessionPath, String zapDir) {
+                        String sessionPath) {
         zapStepParameters = new StartZapStepParameters(host, port, timeout, zapHome, allowedHosts, sessionPath);
     }
 

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
@@ -8,6 +8,7 @@ public class StartZapStepParameters {
     private static String DEFAULT_ZAP_HOME = System.getProperty("ZAP_HOME");
     private static List<String> DEFAULT_ALLOWED_HOSTS = new ArrayList<>();
     private String host;
+    private String zapDir;
     private int port;
     private int timeout;
     private String zapHome;
@@ -23,6 +24,7 @@ public class StartZapStepParameters {
         this.allowedHosts = (allowedHosts == null || allowedHosts.isEmpty()) ? DEFAULT_ALLOWED_HOSTS : allowedHosts;
         this.sessionPath = sessionPath;
     }
+
 
     public String getHost() {
         return host;

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
@@ -8,7 +8,6 @@ public class StartZapStepParameters {
     private static String DEFAULT_ZAP_HOME = System.getProperty("ZAP_HOME");
     private static List<String> DEFAULT_ALLOWED_HOSTS = new ArrayList<>();
     private String host;
-    private String zapDir;
     private int port;
     private int timeout;
     private String zapHome;

--- a/src/test/java/com/vrondakis/zap/ZapDriverStub.java
+++ b/src/test/java/com/vrondakis/zap/ZapDriverStub.java
@@ -15,7 +15,7 @@ public class ZapDriverStub implements ZapDriver {
     private int port;
     private int timeout;
     private String host;
-    private String dir;
+    private FilePath dir;
     private String loadedSessionPath = "";
     private List<String> allowedHosts;
     private HashMap<Integer, Integer> failBuild = new HashMap<>();
@@ -96,7 +96,7 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public void setZapDir(String dir) {
+    public void setZapDir(FilePath dir) {
         this.dir = dir;
     }
 
@@ -129,7 +129,7 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public String getZapDir() {
+    public FilePath getZapDir() {
         return dir;
     }
 

--- a/src/test/java/com/vrondakis/zap/ZapDriverStub.java
+++ b/src/test/java/com/vrondakis/zap/ZapDriverStub.java
@@ -15,6 +15,7 @@ public class ZapDriverStub implements ZapDriver {
     private int port;
     private int timeout;
     private String host;
+    private String dir;
     private String loadedSessionPath = "";
     private List<String> allowedHosts;
     private HashMap<Integer, Integer> failBuild = new HashMap<>();
@@ -95,6 +96,11 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
+    public void setZapDir(String dir) {
+        this.dir = dir;
+    }
+
+    @Override
     public void setFailBuild(int all, int high, int med, int low) {
         failBuild.put(ZapArchive.ALL_ALERT, all);
         failBuild.put(ZapArchive.HIGH_ALERT, high);
@@ -120,6 +126,11 @@ public class ZapDriverStub implements ZapDriver {
     @Override
     public int getZapPort() {
         return port;
+    }
+
+    @Override
+    public String getZapDir() {
+        return dir;
     }
 
     @Override

--- a/src/test/java/com/vrondakis/zap/workflow/ArchiveZapStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/ArchiveZapStepTest.java
@@ -146,7 +146,7 @@ public class ArchiveZapStepTest extends ZapWorkflow {
 
         ZapDriverStub zapDriver = (ZapDriverStub) ZapDriverController.getZapDriver(run);
         Assert.assertNotNull(zapDriver.getZapDir());
-        Assert.assertFalse(new File(zapDriver.getZapDir()).exists());
+        Assert.assertFalse(zapDriver.getZapDir().exists());
 
         r.assertBuildStatus(Result.SUCCESS, run);
         Assert.assertNull(run.getAction(ZapFailBuildAction.class));

--- a/src/test/java/com/vrondakis/zap/workflow/StartZapStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/StartZapStepTest.java
@@ -7,6 +7,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Collections;
 
 public class StartZapStepTest extends ZapWorkflow {
@@ -92,5 +93,40 @@ public class StartZapStepTest extends ZapWorkflow {
         Assert.assertEquals(Collections.singletonList("github.com"), zapDriver.getAllowedHosts());
 
         r.assertBuildStatus(Result.SUCCESS, run);
+    }
+
+
+    @Test
+    public void verifyParametersTestWithDir() throws Exception {
+        int timeout = 234;
+        String sessionPath = "session.session";
+
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     startZap(host: '" + host + "',"
+                + "     port:" + port + ","
+                + "     timeout:" + timeout + ","
+                + "     zapHome: '/opt/zap',"
+                + "     sessionPath:'" + sessionPath + "',"
+                + "     allowedHosts:['github.com'])\n"
+                + "}"
+        ));
+
+
+        run = job.scheduleBuild2(0).get();
+        ZapDriverStub zapDriver = (ZapDriverStub) ZapDriverController.getZapDriver(run);
+
+        Assert.assertEquals(host, zapDriver.getZapHost());
+        Assert.assertEquals(port, zapDriver.getZapPort());
+        Assert.assertNotNull(zapDriver.getZapDir());
+        Assert.assertTrue(new File(zapDriver.getZapDir()).exists());
+        Assert.assertTrue(new File(zapDriver.getZapDir()).isDirectory());
+        Assert.assertEquals(timeout, zapDriver.getZapTimeout());
+        Assert.assertEquals(sessionPath, zapDriver.getLoadedSessionPath());
+        Assert.assertEquals(Collections.singletonList("github.com"), zapDriver.getAllowedHosts());
+
+        r.assertBuildStatus(Result.SUCCESS, run);
+
     }
 }

--- a/src/test/java/com/vrondakis/zap/workflow/StartZapStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/StartZapStepTest.java
@@ -120,8 +120,8 @@ public class StartZapStepTest extends ZapWorkflow {
         Assert.assertEquals(host, zapDriver.getZapHost());
         Assert.assertEquals(port, zapDriver.getZapPort());
         Assert.assertNotNull(zapDriver.getZapDir());
-        Assert.assertTrue(new File(zapDriver.getZapDir()).exists());
-        Assert.assertTrue(new File(zapDriver.getZapDir()).isDirectory());
+        Assert.assertTrue(zapDriver.getZapDir().exists());
+        Assert.assertTrue(zapDriver.getZapDir().isDirectory());
         Assert.assertEquals(timeout, zapDriver.getZapTimeout());
         Assert.assertEquals(sessionPath, zapDriver.getLoadedSessionPath());
         Assert.assertEquals(Collections.singletonList("github.com"), zapDriver.getAllowedHosts());


### PR DESCRIPTION
Hello

when multiple pipeline jobs need Zap at the same time, some of the fail because ZAP never start
Problem is that each ZAP process uses the same /home/<user>/.ZAP folder.
When first instance starts, a lock is created which prevents other processes to start.

This PR tries to create a temp directory in the workspace before ZAP starts and delete it after ZAP stops