### PR TITLE
Report false positives and CSP not disabled

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapAction.java
+++ b/src/main/java/com/vrondakis/zap/ZapAction.java
@@ -59,8 +59,6 @@ public class ZapAction implements Action, RunAction2, SimpleBuildStep.LastBuildA
 
     // Called by Jenkins
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        System.setProperty("hudson.model.DirectoryBrowserSupport.CSP", ""); // Allow JS scripts to be run (content security policy)
-
         DirectoryBrowserSupport dbs = new DirectoryBrowserSupport(this, new FilePath(this.dir()), this.getTitle(),
                 "/plugin/zap-pipeline/logo.png", false);
 

--- a/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
@@ -45,7 +45,7 @@ public class ArchiveZapExecution extends DefaultStepExecutionImpl {
 
         try {
             ZapArchive zapArchive = new ZapArchive(this.run);
-            boolean archiveResult = zapArchive.archiveRawReport(this.run, this.job, this.listener,
+            boolean archiveResult = zapArchive.archiveRawReport(this.run, this.job, this.workspace, this.listener,
                 archiveZapStepParameters.getFalsePositivesFilePath());
             if (!archiveResult) {
                 listener.getLogger().println("zap: Failed to archive results");

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -2,19 +2,19 @@
 <html lang="en">
 <head>
 	<title>ZAP Scanning Report</title>
-	<link href="/plugin/zap-pipeline/normalize.css" rel="stylesheet">
-	<link href="/plugin/zap-pipeline/skeleton.css" rel="stylesheet">
-	<link href="/plugin/zap-pipeline/main.css" rel="stylesheet">
+	<link href="normalize.css" rel="stylesheet">
+	<link href="skeleton.css" rel="stylesheet">
+	<link href="main.css" rel="stylesheet">
 
-	<script src="/plugin/zap-pipeline/angular.min.js"></script>
-	<script src="/plugin/zap-pipeline/main.js"></script>
+	<script src="angular.min.js"></script>
+	<script src="main.js"></script>
 
 </head>
 <body data-ng-app="zap" data-ng-controller="mainController" data-ng-init="load()">
 
 <div class="navbar" ng-class="{'low' : counts.low > 0, 'medium' : counts.medium > 0, 'high': counts.high > 0}">
 	<div class="navbar-container">
-		<a data-ng-click="goBack()"><img alt="Back" src="/plugin/zap-pipeline/back.png"></a>
+		<a data-ng-click="goBack()"><img alt="Back" src="back.png"></a>
 	</div>
 </div>
 

--- a/src/main/webapp/main.js
+++ b/src/main/webapp/main.js
@@ -69,10 +69,20 @@ var createFalsePositive = function(alert, instance) {
 }
 
 // A false positive matches an alert instance if all the values set in the false positive match
-// the values in the instance and alert
+// the values in the instance and alert. The uri value of a false positive will be a regex, so it's tested differently
 var falsePositiveMatch = function(falsePositive, alert, instance) {
 	return Object.keys(falsePositive).every(key => {
-		return !falsePositive.hasOwnProperty(key) || falsePositive[key] === alert[key] || falsePositive[key] === instance[key]
+	    if (!falsePositive.hasOwnProperty(key)) {
+	        return true;
+	    }
+	    if (key == "uri") {
+	        if (!instance.hasOwnProperty("uri")) {
+	            return false;
+	        }
+            var falsePattern = new RegExp(falsePositive["uri"]);
+            return falsePattern.test(instance["uri"]);
+	    }
+		return falsePositive[key] === alert[key] || falsePositive[key] === instance[key]
 	})
 }
 


### PR DESCRIPTION
False positive file is found in the workspace not the root.
All static files required for report are saved, can now use the Jenkins Resource Root URL and no longer need to disable the Content Security Policy.

[False positive file not working #7:](https://github.com/jenkinsci/zap-pipeline-plugin/issues/7)
Changed the archiveRawReport function so it now looks for the false positives file in the workspace and not the root directory.

[False posivites are not filtered out in report view #9:](https://github.com/jenkinsci/zap-pipeline-plugin/issues/9)
[False Positive File Not Suppressed #11:](https://github.com/jenkinsci/zap-pipeline-plugin/issues/11)
Changed the check in main.js of the report so it correctly uses regex when comparing the uri.
(this would be better if code was refactored to have alerts already marked as false positives, but that would be a lot more work.)

[Jenkins plugin security warning #18:](https://github.com/jenkinsci/zap-pipeline-plugin/issues/18)
The Content Security Policy is no longer disabled, for this to work you'll need to specify the Resource Root URL in Jenkins.
So that the report continues to work with this change, the saveStaticFiles function now also copies the js and css files.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [x] to show you have filled the information
-->
