### PR TITLE
Changed the <url> field in pom.xml so that it points to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         </license>
     </licenses>
 
-    <url>https://wiki.jenkins.io/display/JENKINS/Zap+Pipeline+Plugin</url>
+    <url>https://github.com/jenkinsci/zap-pipeline-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
Updated the url so plugin will be visible again in the Jenkins Plugins site (documentation was moved from wiki).