### PR TITLE
Improved Error Handling and Added "External Zap" options

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapAction.java
+++ b/src/main/java/com/vrondakis/zap/ZapAction.java
@@ -42,11 +42,9 @@ import jenkins.tasks.SimpleBuildStep;
 public class ZapAction implements Action, RunAction2, SimpleBuildStep.LastBuildAction {
     private final Run<?, ?> run;
     private transient ZapTrendChart zapTrendChart;
-    private boolean showButton;
 
-    public ZapAction(Run<?, ?> run, boolean showButton) {
+    public ZapAction(Run<?, ?> run) {
         this.run = run;
-        this.showButton = showButton;
     }
 
     public Run<?, ?> getRun() {
@@ -175,12 +173,12 @@ public class ZapAction implements Action, RunAction2, SimpleBuildStep.LastBuildA
 
     @Override
     public String getDisplayName() {
-        return showButton ? "ZAP Scanning Report" : null;
+        return "ZAP Scanning Report";
     }
 
     @Override
     public String getIconFileName() {
-        return showButton ? "/plugin/zap-pipeline/logo.png" : null;
+        return "/plugin/zap-pipeline/logo.png";
     }
 
     protected String getTitle() {

--- a/src/main/java/com/vrondakis/zap/ZapDriver.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriver.java
@@ -16,27 +16,27 @@ public interface ZapDriver {
     int ZAP_INITIALIZE_TIMEOUT = 100;
     int ZAP_INITIALIZE_WAIT = 20;
 
-    boolean shutdownZap();
+    void shutdownZap() throws ZapExecutionException;
 
-    boolean setZapMode(String zapMode);
+    void setZapMode(String zapMode) throws ZapExecutionException;
 
-    boolean startZapCrawler(String host);
+    void startZapCrawler(String host) throws ZapExecutionException, ZapExecutionException;
 
     int zapCrawlerStatus();
 
-    boolean importUrls(String path);
+    void importUrls(String path) throws ZapExecutionException;
 
-    boolean loadSession(String sessionPath);
+    void loadSession(String sessionPath) throws ZapExecutionException;
 
-    boolean loadPolicy(String policy);
+    void loadPolicy(String policy) throws ZapExecutionException;
 
-    boolean zapAttack(RunZapAttackStepParameters zsp);
+    boolean zapAttack(RunZapAttackStepParameters zsp) throws ZapExecutionException, UnirestException, IOException, URISyntaxException;
 
-    boolean zapCrawlerSuccess();
+    void zapCrawlerSuccess() throws InterruptedException, ZapExecutionException;
 
     int zapAttackStatus();
 
-    boolean startZapProcess(String zapHome, FilePath ws, Launcher launcher);
+    void startZapProcess(String zapHome, FilePath ws, Launcher launcher) throws IOException;
 
     void setZapHost(String zapHost);
 
@@ -65,7 +65,7 @@ public interface ZapDriver {
     String getZapReport() throws IOException, UnirestException, URISyntaxException;
     String getZapReportXML() throws IOException, UnirestException, URISyntaxException;
 
-    boolean zapAliveCheck();
+    void zapAliveCheck() throws ZapExecutionException;
     
-    int zapRecordsToScan();
+    int zapRecordsToScan() throws ZapExecutionException;
 }

--- a/src/main/java/com/vrondakis/zap/ZapDriverController.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverController.java
@@ -32,8 +32,9 @@ public class ZapDriverController {
 
     public static ZapDriver getZapDriver(Run run) {
         ZapDriver driver = zapDrivers.get(run.getUrl());
-        if (driver != null)
+        if (driver != null) {
             return driver;
+        }
 
         System.out.println("zap: Creating new ZAP driver for build URL: " + run.getUrl());
         return newDriver(run);
@@ -59,13 +60,12 @@ public class ZapDriverController {
         return zapDrivers.containsKey(run.getUrl());
     }
 
-    public static boolean shutdownZap(Run run) {
-        boolean success = getZapDriver(run).shutdownZap();
+    public static void shutdownZap(Run run) throws ZapExecutionException {
+        getZapDriver(run).shutdownZap();
 
-        if (zapDrivers.get(run.getUrl()) instanceof ZapDriverImpl)
+        if (zapDrivers.get(run.getUrl()) instanceof ZapDriverImpl) {
             zapDrivers.remove(run.getUrl());
-
-        return success;
+        }
     }
 
     // Converts map of parameters to URL parameters

--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -78,9 +78,10 @@ public class ZapDriverImpl implements ZapDriver {
     }
 
     public void shutdownZap() throws ZapExecutionException {
-        if (0 == zapPort || null == zapHost) {
+        if (zapPort == 0 || zapHost == null) {
             throw new ZapExecutionException("Cannot shutdown Zap, missing Port and/or Host value.");
         }
+
         zapApi("core/action/shutdown");
     }
 

--- a/src/main/java/com/vrondakis/zap/ZapExecutionException.java
+++ b/src/main/java/com/vrondakis/zap/ZapExecutionException.java
@@ -1,0 +1,32 @@
+/* HEADER */
+package com.vrondakis.zap;
+
+import java.io.PrintStream;
+
+public class ZapExecutionException extends Exception {
+    private boolean listener;
+
+    public ZapExecutionException(String message) {
+        super(message);
+    }
+
+    public ZapExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ZapExecutionException(String message, PrintStream logger) {
+        super(message);
+        logMessage(message, logger);
+    }
+
+    public ZapExecutionException(String message, Throwable cause, PrintStream logger) {
+        super(message, cause);
+        logMessage(message, logger);
+    }
+
+    private void logMessage(String message, PrintStream logger) {
+        if (logger != null) {
+            logger.println("zap: " + message);
+        }
+    }
+}

--- a/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ArchiveZapExecution.java
@@ -18,9 +18,8 @@ import java.time.OffsetDateTime;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Executor for archiveZap() function in Jenkinsfile
+ * Executor for archiveZap() function in Jenkins
  */
-
 public class ArchiveZapExecution extends DefaultStepExecutionImpl {
     private ArchiveZapStepParameters archiveZapStepParameters;
 
@@ -81,7 +80,9 @@ public class ArchiveZapExecution extends DefaultStepExecutionImpl {
             FilePath zapDir = zap.getZapDir();
 
             try {
-                ZapDriverController.shutdownZap(this.run);
+                if (archiveZapStepParameters.shouldShutdown()) {
+                    ZapDriverController.shutdownZap(this.run);
+                }
             } catch (Exception e) {
                 listener.getLogger().println("zap: Failed to shutdown ZAP. " + e.getMessage());
             }

--- a/src/main/java/com/vrondakis/zap/workflow/ArchiveZapStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ArchiveZapStep.java
@@ -14,7 +14,7 @@ public class ArchiveZapStep extends Step implements Serializable {
     private final ArchiveZapStepParameters archiveZapStepParameters;
 
     /**
-     * Analyse the zap attack and generate the zap report
+     * Analyse the zap attack and generate the zap report, then stop the zap instance.
      *
      * @param failAllAlerts          Fail the run if there is x or more of any type of alert - default 0 (disabled)
      * @param failHighAlerts         Fail the run when there is x or more of HIGH risk alerts - default 1
@@ -22,12 +22,13 @@ public class ArchiveZapStep extends Step implements Serializable {
      * @param failLowAlerts          Fail the run when there is more x or more LOW risk alerts - default 0 (disabled)
      * @param falsePositivesFilePath File name and path (relative to workspace) to the falsePositives config file - default
      *                               "zapfalsePositives.json"
+     * @param keepAlive              If true, the zap application will not be sent the shutdown command.
      */
     @DataBoundConstructor
     public ArchiveZapStep(Integer failAllAlerts, Integer failHighAlerts, Integer failMediumAlerts, Integer failLowAlerts,
-                          String falsePositivesFilePath) {
+                          String falsePositivesFilePath, boolean keepAlive) {
         this.archiveZapStepParameters = new ArchiveZapStepParameters(failAllAlerts, failHighAlerts, failMediumAlerts,
-                failLowAlerts, falsePositivesFilePath);
+                failLowAlerts, falsePositivesFilePath, keepAlive);
     }
 
     @Override

--- a/src/main/java/com/vrondakis/zap/workflow/ArchiveZapStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ArchiveZapStepParameters.java
@@ -13,15 +13,17 @@ public class ArchiveZapStepParameters implements Serializable {
     private int failMediumAlerts;
     private int failLowAlerts;
     private String falsePositivesFilePath;
+    private boolean keepAlive;
 
     public ArchiveZapStepParameters(Integer failAllAlerts, Integer failHighAlerts, Integer failMediumAlerts,
-                                    Integer failLowAlerts, String falsePositivesFilePath) {
+                                    Integer failLowAlerts, String falsePositivesFilePath, boolean keepAlive) {
         this.failAllAlerts = failAllAlerts == null ? DEFAULT_FAIL_ALL : failAllAlerts;
         this.failHighAlerts = failHighAlerts == null ? DEFAULT_FAIL_HIGH : failHighAlerts;
         this.failMediumAlerts = failMediumAlerts == null ? DEFAULT_FAIL_MED : failMediumAlerts;
         this.failLowAlerts = failLowAlerts == null ? DEFAULT_FAIL_LOW : failLowAlerts;
         this.failLowAlerts = failLowAlerts == null ? DEFAULT_FAIL_LOW : failLowAlerts;
         this.falsePositivesFilePath = falsePositivesFilePath == null ? DEFAULT_FALSE_POSITIVES_FILE_PATH : falsePositivesFilePath;
+        this.keepAlive = keepAlive;
     }
 
     public int getFailAllAlerts() {
@@ -42,5 +44,9 @@ public class ArchiveZapStepParameters implements Serializable {
 
     public String getFalsePositivesFilePath() {
         return falsePositivesFilePath;
+    }
+
+    public boolean shouldShutdown() {
+        return !keepAlive;
     }
 }

--- a/src/main/java/com/vrondakis/zap/workflow/ImportZapPolicyExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ImportZapPolicyExecution.java
@@ -3,6 +3,7 @@ package com.vrondakis.zap.workflow;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import com.vrondakis.zap.ZapExecutionException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import com.vrondakis.zap.ZapDriver;
@@ -20,16 +21,15 @@ public class ImportZapPolicyExecution extends DefaultStepExecutionImpl {
     public boolean start() {
         listener.getLogger().println("zap: Loading attack policy...");
         if (importZapPolicyStepParameters == null || importZapPolicyStepParameters.getPolicyPath().isEmpty()) {
-            getContext().onFailure(new Throwable("zap: Policy path not provided!"));
+            getContext().onFailure(new ZapExecutionException("Policy path not provided.", listener.getLogger()));
             return false;
         }
 
         ZapDriver zapDriver = ZapDriverController.getZapDriver(this.run);
-        boolean success = zapDriver.loadPolicy(importZapPolicyStepParameters.getPolicyPath());
-        if (!success) {
-            listener.getLogger().println("zap: Failed to load attack policy at " + importZapPolicyStepParameters.getPolicyPath());
-            getContext().onFailure(
-                    new Throwable("zap: Failed to load attack policy at " + importZapPolicyStepParameters.getPolicyPath()));
+        try {
+            zapDriver.loadPolicy(importZapPolicyStepParameters.getPolicyPath());
+        } catch (Exception e) {
+            getContext().onFailure(new ZapExecutionException("Failed to load attack policy at " + importZapPolicyStepParameters.getPolicyPath(), e, listener.getLogger()));
             return false;
         }
 

--- a/src/main/java/com/vrondakis/zap/workflow/ImportZapUrlsExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ImportZapUrlsExecution.java
@@ -3,6 +3,7 @@ package com.vrondakis.zap.workflow;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
+import com.vrondakis.zap.ZapExecutionException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
 import com.vrondakis.zap.ZapDriver;
@@ -21,16 +22,16 @@ public class ImportZapUrlsExecution extends DefaultStepExecutionImpl {
         listener.getLogger().println("zap: Importing list of URLs...");
 
         if (importZapUrlsStepParameters == null || importZapUrlsStepParameters.getPath().isEmpty()) {
-            getContext().onFailure(new Throwable("zap: Could not load URLs file"));
+            getContext().onFailure(new ZapExecutionException("Could not load URLs file.", listener.getLogger()));
             return false;
         }
 
         ZapDriver zapDriver = ZapDriverController.getZapDriver(this.run);
 
-        boolean success = zapDriver.importUrls(importZapUrlsStepParameters.getPath());
-        if (!success) {
-            listener.getLogger().println("zap: Failed to load list of URLs at " + importZapUrlsStepParameters.getPath());
-            getContext().onFailure(new Throwable("zap: Failed to load list of URLs at " + importZapUrlsStepParameters.getPath()));
+        try {
+            zapDriver.importUrls(importZapUrlsStepParameters.getPath());
+        } catch (Exception e) {
+            getContext().onSuccess(new ZapExecutionException("Failed to load list of URLs at " + importZapUrlsStepParameters.getPath(), e, listener.getLogger()));
             return false;
         }
 

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapExecution.java
@@ -9,6 +9,8 @@ import java.nio.file.Files;
 import java.time.OffsetDateTime;
 import java.util.concurrent.TimeUnit;
 
+import com.vrondakis.zap.ZapExecutionException;
+import org.apache.commons.lang.ObjectUtils;
 import hudson.FilePath;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import com.vrondakis.zap.ZapDriver;
@@ -36,24 +38,21 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
             try {
                 launcher = new Launcher.RemoteLauncher(listener, workspace.getChannel(), node.toComputer().isUnix());
             } catch (NullPointerException e) {
-                this.listener.getLogger().println("zap: Could not start ZAP. Failed to retrieve OS information");
-                getContext().onSuccess(false);
+                getContext().onFailure(new ZapExecutionException("Could not start ZAP. Failed to retrieve OS information", e, listener.getLogger()));
                 return false;
             }
         }
 
         // No parameters
         if (zapStepParameters == null) {
-            this.listener.getLogger().println("zap: Could not start ZAP. No parameters are provided - startZap");
-            getContext().onFailure(new Throwable("zap: Could not start ZAP. No parameters are provided - startZap"));
+            getContext().onFailure(new ZapExecutionException("Could not start ZAP. No parameters are provided.", listener.getLogger()));
             return false;
         }
 
         // Zap home not set / invalid
         this.listener.getLogger().println("zap: Starting ZAP on port " + zapStepParameters.getPort() + "...");
         if (zapStepParameters.getZapHome() == null || zapStepParameters.getZapHome().isEmpty()) {
-            this.listener.getLogger().println("zap: Did not start ZAP process because zapHome is not set");
-            getContext().onFailure(new Throwable("zap: Did not start ZAP process because zapHome is not set"));
+            getContext().onFailure(new ZapExecutionException("Did not start ZAP process because zapHome is not set.", listener.getLogger()));
             return false;
         }
 
@@ -61,12 +60,11 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
         // See https://github.com/jenkinsci/zap-pipeline-plugin/issues/8
         try {
             if (!workspace.exists()) {
-                launcher.getListener().getLogger().println("Creating workspace directory...");
+                listener.getLogger().println("Creating workspace directory...");
                 workspace.mkdirs();
             }
         } catch (Exception e) {
-            launcher.getListener().getLogger().println("Unable to create workspace dir: " + e.toString());
-            e.printStackTrace();
+            getContext().onFailure(new ZapExecutionException("Unable to create workspace dir.", e, listener.getLogger()));
             return false;
         }
 
@@ -75,7 +73,8 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
         try {
             zapDir = workspace.createTempDir( "zaptemp", "");
         } catch (IOException | InterruptedException e) {
-            e.printStackTrace();
+            getContext().onFailure(new ZapExecutionException("Unable to create temporary zap folder.", e, listener.getLogger()));
+            return false;
         }
 
         ZapDriver zapDriver = ZapDriverController.newDriver(this.run);
@@ -86,11 +85,10 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
         zapDriver.setZapTimeout(zapStepParameters.getTimeout());
         zapDriver.setAllowedHosts(zapStepParameters.getAllowedHosts());
 
-
-        boolean success = zapDriver.startZapProcess(zapStepParameters.getZapHome(), workspace, launcher);
-        if (!success) {
-            this.listener.getLogger().println("zap: Failed to start ZAP process");
-            getContext().onFailure(new Throwable("zap: Failed to start ZAP process"));
+        try {
+            zapDriver.startZapProcess(zapStepParameters.getZapHome(), workspace, launcher);
+        } catch (Exception e) {
+            getContext().onFailure(new ZapExecutionException("Failed to start ZAP process.", e, listener.getLogger()));
             return false;
         }
 
@@ -98,22 +96,24 @@ public class StartZapExecution extends DefaultStepExecutionImpl {
 
         // Wait for ZAP to start before continuing...
         listener.getLogger().println("zap: Waiting for ZAP to initialize...");
-        boolean zapHasStarted = zapDriver.zapAliveCheck();
 
-        if (!zapHasStarted) {
-            this.listener.getLogger().println("zap: Failed to start ZAP on port " + zapDriver.getZapPort());
-            getContext().onFailure(
-                    new Throwable("zap: Failed to start ZAP on " + zapDriver.getZapHost() + ":" + zapDriver.getZapPort() + ". Socket timed out"));
-
+        try {
+            zapDriver.zapAliveCheck();
+        } catch (Exception e) {
+            getContext().onFailure(new ZapExecutionException("Failed to start ZAP on " + zapDriver.getZapHost() + ":" + zapDriver.getZapPort(), e, listener.getLogger()));
             return false;
         }
 
         // Load session
         if (zapStepParameters.getSessionPath() != null && !zapStepParameters.getSessionPath().isEmpty()) {
             this.listener.getLogger().println("zap: Loading session " + zapStepParameters.getSessionPath());
-            boolean loadedSession = zapDriver.loadSession(zapStepParameters.getSessionPath());
-            if (!loadedSession)
-                getContext().onFailure(new Throwable("zap: Could not load session file"));
+
+            try {
+                zapDriver.loadSession(zapStepParameters.getSessionPath());
+            } catch (Exception e) {
+                getContext().onFailure(new ZapExecutionException("Could not load session file.", e, listener.getLogger()));
+                return false;
+            }
         }
 
         getContext().onSuccess(true);

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStep.java
@@ -20,15 +20,15 @@ public class StartZapStep extends Step {
      * @param host         The host to run ZAP on - default localhost
      * @param port         The port to run ZAP on - default 9092
      * @param timeout      The amount of seconds to let the ZAP attack run for before it quits - default 1000
-     * @param zapHome      Where the zap process is located - if not set this will not start ZAP (but still make calls if you're running
-     *                     it locally)
+     * @param zapHome      Where the zap process is located - this must be set if you are not using an external managed ZAP application.
      * @param allowedHosts The hosts to allow scans to begin on, if none are specified then it will run the attack locally only
      * @param sessionPath  Optional path to the session file
+     * @param externalZap  Set to true, ZAP application is externally managed.
      */
     @DataBoundConstructor
     public StartZapStep(@CheckForNull String host, int port, int timeout, String zapHome, List<String> allowedHosts,
-                        String sessionPath) {
-        zapStepParameters = new StartZapStepParameters(host, port, timeout, zapHome, allowedHosts, sessionPath);
+                        String sessionPath, boolean externalZap) {
+        zapStepParameters = new StartZapStepParameters(host, port, timeout, zapHome, allowedHosts, sessionPath, externalZap);
     }
 
     @Override

--- a/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StartZapStepParameters.java
@@ -13,15 +13,17 @@ public class StartZapStepParameters {
     private String zapHome;
     private List<String> allowedHosts;
     private String sessionPath;
+    private boolean externalZap;
 
     public StartZapStepParameters(String host, int port, int timeout, String zapHome, List<String> allowedHosts,
-                                  String sessionPath) {
+                                  String sessionPath, boolean externalZap) {
         this.host = host;
         this.port = port;
         this.timeout = timeout == 0 ? DEFAULT_TIMEOUT : timeout;
         this.zapHome = (zapHome == null || zapHome.isEmpty()) ? DEFAULT_ZAP_HOME : zapHome;
         this.allowedHosts = (allowedHosts == null || allowedHosts.isEmpty()) ? DEFAULT_ALLOWED_HOSTS : allowedHosts;
         this.sessionPath = sessionPath;
+        this.externalZap = externalZap;
     }
 
 
@@ -47,5 +49,13 @@ public class StartZapStepParameters {
 
     public String getSessionPath() {
         return sessionPath;
+    }
+
+    public boolean isExternalZap() {
+        return externalZap;
+    }
+
+    public void setExternalZap(boolean externalZap) {
+        this.externalZap = externalZap;
     }
 }

--- a/src/main/java/com/vrondakis/zap/workflow/StopZapExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StopZapExecution.java
@@ -1,0 +1,50 @@
+package com.vrondakis.zap.workflow;
+
+import com.vrondakis.zap.ZapArchive;
+import com.vrondakis.zap.ZapDriver;
+import com.vrondakis.zap.ZapDriverController;
+import com.vrondakis.zap.ZapExecutionException;
+import com.vrondakis.zap.ZapFailBuildAction;
+import hudson.FilePath;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executor for stopZap() function in Jenkins
+ */
+public class StopZapExecution extends DefaultStepExecutionImpl {
+    public StopZapExecution(StepContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean start() {
+        listener.getLogger().println("zap: Stopping Zap...");
+        System.out.println("zap: Stopping Zap...");
+
+        ZapDriver zap = ZapDriverController.getZapDriver(this.run);
+        FilePath zapDir = zap.getZapDir();
+
+        try {
+            ZapDriverController.shutdownZap(this.run);
+        } catch (Exception e) {
+            listener.getLogger().println("zap: Failed to shutdown ZAP.");
+        }
+
+        if (zapDir != null) {
+            try {
+                listener.getLogger().println("zap: Deleting temp directory: " + zapDir.getRemote());
+                zapDir.deleteRecursive();
+            } catch (IOException | InterruptedException e) {
+                listener.getLogger().println("zap: Failed to delete temp directory. " + e.getMessage());
+            }
+        }
+
+        getContext().onSuccess(true);
+        return true;
+    }
+}

--- a/src/main/java/com/vrondakis/zap/workflow/StopZapStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/StopZapStep.java
@@ -1,0 +1,31 @@
+package com.vrondakis.zap.workflow;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+
+public class StopZapStep extends Step implements Serializable {
+    /**
+     * Stop (shutdown) the zap instance.
+     */
+    @DataBoundConstructor
+    public StopZapStep() {}
+
+    @Override
+    public StepExecution start(StepContext context) throws IOException, InterruptedException {
+        return new StopZapExecution(context);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends DefaultStepDescriptorImpl<ArchiveZapExecution> {
+        public DescriptorImpl() {
+            super(ArchiveZapExecution.class, "stopZap", "Stop the ZAP instance.");
+        }
+    }
+}

--- a/src/test/java/com/vrondakis/zap/ZapArchiveTest.java
+++ b/src/test/java/com/vrondakis/zap/ZapArchiveTest.java
@@ -57,14 +57,14 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testDirectoryCreation() throws IOException, InterruptedException {
+    public void testDirectoryCreation() throws IOException, InterruptedException, ZapExecutionException {
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
         Assert.assertTrue(zapDirectoryA.isDirectory());
     }
 
     @Test
-    public void testStaticFileSaving() throws IOException, InterruptedException {
+    public void testStaticFileSaving() throws ZapExecutionException, IOException, InterruptedException {
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
         String[] staticFiles = {"index.html", "angular.min.js", "main.js", "normalize.css", "skeleton.css", "main.css", "back.png"};
@@ -76,7 +76,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testFalsePositiveFileSaving() throws IOException, InterruptedException {
+    public void testFalsePositiveFileSaving() throws IOException, InterruptedException, ZapExecutionException {
         saveFalsePositives(zapRunA);
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
@@ -86,7 +86,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testAlertCounts() throws IOException, InterruptedException {
+    public void testAlertCounts() throws IOException, InterruptedException, ZapExecutionException {
         // Archive both of the reports
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
@@ -100,7 +100,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testAlertCountsFalsePositive() throws IOException, InterruptedException {
+    public void testAlertCountsFalsePositive() throws IOException, InterruptedException, ZapExecutionException {
         // Save the false positives file for zapRunA, so the alert counts will be different
         saveFalsePositives(zapRunA);
 
@@ -117,7 +117,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void checkPreviousReport() throws IOException, InterruptedException {
+    public void checkPreviousReport() throws IOException, InterruptedException, ZapExecutionException {
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
         zapArchiveB.archiveRawReport(zapRunB, job, zapWorkspaceB, taskListener, "false-positives.json");
 
@@ -129,7 +129,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testActionCreated() {
+    public void testActionCreated() throws ZapExecutionException {
         // Archive both builds
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
@@ -139,14 +139,14 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testActionNotCreated() {
+    public void testActionNotCreated() throws ZapExecutionException {
         // Archive both builds
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
         Assert.assertNull(zapRunA.getParent().getAction(ZapAction.class));
     }
 
     @Test
-    public void testFailBuildFalse() throws IOException, InterruptedException {
+    public void testFailBuildFalse() throws IOException, InterruptedException, ZapExecutionException {
         saveFalsePositives(zapRunA);
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 
@@ -154,7 +154,7 @@ public class ZapArchiveTest extends ZapTests {
     }
 
     @Test
-    public void testFailBuild() throws IOException, InterruptedException {
+    public void testFailBuild() throws IOException, InterruptedException, ZapExecutionException {
         saveFalsePositives(zapRunA);
         zapArchiveA.archiveRawReport(zapRunA, job, zapWorkspaceA, taskListener, "false-positives.json");
 

--- a/src/test/java/com/vrondakis/zap/ZapDriverStub.java
+++ b/src/test/java/com/vrondakis/zap/ZapDriverStub.java
@@ -30,18 +30,18 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public boolean shutdownZap() {
-        return false;
+    public void shutdownZap() {
+        // Do nothing
     }
 
     @Override
-    public boolean setZapMode(String zapMode) {
-        return false;
+    public void setZapMode(String zapMode) {
+        // Do nothing
     }
 
     @Override
-    public boolean startZapCrawler(String host) {
-        return true;
+    public void startZapCrawler(String host) {
+        // Do nothing
     }
 
     @Override
@@ -50,19 +50,18 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public boolean importUrls(String path) {
-        return true;
+    public void importUrls(String path) {
+        // Do nothing
     }
 
     @Override
-    public boolean loadSession(String sessionPath) {
+    public void loadSession(String sessionPath) {
         loadedSessionPath = sessionPath;
-        return true;
     }
 
     @Override
-    public boolean loadPolicy(String policy) {
-        return true;
+    public void loadPolicy(String policy) {
+        // Do nothing
     }
 
     @Override
@@ -71,8 +70,8 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public boolean zapCrawlerSuccess() {
-        return true;
+    public void zapCrawlerSuccess() {
+        // Do nothing
     }
 
     @Override
@@ -81,8 +80,8 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public boolean startZapProcess(String zapHome, FilePath ws, Launcher launcher) {
-        return true;
+    public void startZapProcess(String zapHome, FilePath ws, Launcher launcher) {
+        // do nothing
     }
 
     @Override
@@ -161,8 +160,8 @@ public class ZapDriverStub implements ZapDriver {
     }
 
     @Override
-    public boolean zapAliveCheck() {
-        return true;
+    public void zapAliveCheck() {
+        // Do nothing
     }
 
 	@Override

--- a/src/test/java/com/vrondakis/zap/ZapDriverStub.java
+++ b/src/test/java/com/vrondakis/zap/ZapDriverStub.java
@@ -19,7 +19,7 @@ public class ZapDriverStub implements ZapDriver {
     private String loadedSessionPath = "";
     private List<String> allowedHosts;
     private HashMap<Integer, Integer> failBuild = new HashMap<>();
-
+    boolean zapWasShutdown = false;
 
     public ZapDriverStub() {
         super();
@@ -31,7 +31,11 @@ public class ZapDriverStub implements ZapDriver {
 
     @Override
     public void shutdownZap() {
-        // Do nothing
+        zapWasShutdown = true;
+    }
+
+    public boolean isZapShutdown() {
+        return zapWasShutdown;
     }
 
     @Override

--- a/src/test/java/com/vrondakis/zap/workflow/ArchiveZapStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/ArchiveZapStepTest.java
@@ -18,6 +18,7 @@ public class ArchiveZapStepTest extends ZapWorkflow {
     public void testFailureParametersSet() throws Exception {
         job.setDefinition(new CpsFlowDefinition(""
                 + "node('slave') {\n"
+                + "     startZap(zapHome: '/', port: 1234, host:'123.123.123.123')\n"
                 + "     archiveZap("
                 + "         failAllAlerts: 313,"
                 + "         failHighAlerts: 314,"

--- a/src/test/java/com/vrondakis/zap/workflow/StopZapStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/StopZapStepTest.java
@@ -1,0 +1,52 @@
+package com.vrondakis.zap.workflow;
+
+import com.vrondakis.zap.ZapArchive;
+import com.vrondakis.zap.ZapDriverController;
+import com.vrondakis.zap.ZapDriverStub;
+import com.vrondakis.zap.ZapFailBuildAction;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+
+public class StopZapStepTest extends ZapWorkflow {
+    @Test
+    public void zapIsShutdown() throws Exception {
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     startZap(zapHome: '/', port: 1234, host:'123.123.123.123')\n"
+                + "     stopZap()\n"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+        ZapDriverStub zapDriver = (ZapDriverStub) ZapDriverController.getZapDriver(run);
+
+        r.assertBuildStatus(Result.SUCCESS, run);
+        Assert.assertNull(run.getAction(ZapFailBuildAction.class));
+        Assert.assertTrue(zapDriver.isZapShutdown());
+    }
+
+    @Test
+    public void testTempFolderDeletedOnArchive() throws Exception {
+        // check temp directory has been deleted after archiving
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     startZap(zapHome: '/', port: 1234, host:'123.123.123.123')\n"
+                + "     stopZap()\n"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+
+        ZapDriverStub zapDriver = (ZapDriverStub) ZapDriverController.getZapDriver(run);
+        Assert.assertNotNull(zapDriver.getZapDir());
+        Assert.assertFalse(zapDriver.getZapDir().exists());
+
+        r.assertBuildStatus(Result.SUCCESS, run);
+        Assert.assertNull(run.getAction(ZapFailBuildAction.class));
+    }
+}


### PR DESCRIPTION
Improved Error Handling, so that the original cause is preserved and passed down. Hopefully this can help debug unclear issues such as #15, #8.

Added the following new parameters and steps for #13:

- Added startZap option "externalZap", which prevents the need for Zap Home and does not attempt to start a local version of zap.
- Also added archiveZap "keepAlive" so that zap is not sent the shutdown command after archiving (for either externally managed zap applications, or when you are doing multiple attacks/archives using the same instance).
- Added new step "stopZap" that simply sends zap the shutdown command. Can be used at the end after running multiple attacks/archiving steps.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
