### PR TITLE
Add action to configure IDs of the passive rules that will be enabled or disabled

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapDriver.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriver.java
@@ -38,6 +38,10 @@ public interface ZapDriver {
 
     void startZapProcess(String zapHome, FilePath ws, Launcher launcher) throws IOException;
 
+    void enablePassiveScanners(List<Integer> ids) throws ZapExecutionException;
+
+    void disablePassiveScanners(List<Integer> ids) throws ZapExecutionException;
+
     void setZapHost(String zapHost);
 
     void setZapPort(int zapPort);

--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -10,12 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 
@@ -362,6 +359,32 @@ public class ZapDriverImpl implements ZapDriver {
 
         launcher.launch().stdout(launcher.getListener().getLogger()).stderr(launcher.getListener().getLogger()).cmds(cmd).pwd(ws).start();
         launcher.getListener().getLogger().println("zap: Started successfully");
+    }
+
+    @Override
+    public void enablePassiveScanners(List<Integer> ids) throws ZapExecutionException {
+        zapApi("pscan/action/disableAllScanners/");
+
+        String commaIds = String.join(",", ids
+                .stream()
+                .map(id -> id.toString())
+                .collect(Collectors.toList()));
+        Map<String, String> arguments = new HashMap<>();
+        arguments.put("ids", commaIds);
+        zapApi("pscan/action/enableScanners/", arguments);
+    }
+
+    @Override
+    public void disablePassiveScanners(List<Integer> ids) throws ZapExecutionException {
+        zapApi("pscan/action/enableAllScanners/");
+
+        String commaIds = String.join(",", ids
+                .stream()
+                .map(id -> id.toString())
+                .collect(Collectors.toList()));
+        Map<String, String> arguments = new HashMap<>();
+        arguments.put("ids", commaIds);
+        zapApi("pscan/action/disableScanners/", arguments);
     }
 
     @Override

--- a/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesExecution.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesExecution.java
@@ -1,0 +1,55 @@
+package com.vrondakis.zap.workflow;
+
+import com.vrondakis.zap.ZapDriver;
+import com.vrondakis.zap.ZapDriverController;
+import com.vrondakis.zap.ZapExecutionException;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class ConfigurePassiveRulesExecution extends DefaultStepExecutionImpl {
+    private ConfigurePassiveRulesStepParameters configurePassiveRulesStepParameters;
+
+    public ConfigurePassiveRulesExecution(StepContext context, ConfigurePassiveRulesStepParameters configurePassiveRulesStepParameters) {
+        super(context);
+        this.configurePassiveRulesStepParameters = configurePassiveRulesStepParameters;
+    }
+
+    @Override
+    public boolean start() {
+        listener.getLogger().println("zap: Configuring passive rules ...");
+
+        if (configurePassiveRulesStepParameters == null
+                || configurePassiveRulesStepParameters.getAction().isEmpty()
+                || (!"enablePassiveScanners".equalsIgnoreCase(configurePassiveRulesStepParameters.getAction())
+                    && !"disablePassiveScanners".equalsIgnoreCase(configurePassiveRulesStepParameters.getAction()))
+        ) {
+            getContext().onFailure(new ZapExecutionException("Action name should be 'enablePassiveScanners' or 'disablePassiveScanners'", listener.getLogger()));
+            return false;
+        }
+
+        ZapDriver zapDriver = ZapDriverController.getZapDriver(this.run);
+
+        try {
+            if ("enablePassiveScanners".equalsIgnoreCase(configurePassiveRulesStepParameters.getAction())) {
+                zapDriver.enablePassiveScanners(configurePassiveRulesStepParameters.getIds());
+            } else if ("disablePassiveScanners".equalsIgnoreCase(configurePassiveRulesStepParameters.getAction())) {
+                zapDriver.disablePassiveScanners(configurePassiveRulesStepParameters.getIds());
+            }
+        } catch (Exception e) {
+            getContext().onSuccess(new ZapExecutionException("Failed to configure passive scanner rules " + configurePassiveRulesStepParameters.getIds(), e, listener.getLogger()));
+            return false;
+        }
+
+        getContext().onSuccess(true);
+        return true;
+    }
+
+    // findbugs fails without this because "non-transient non-serializable instance field in serializable class"
+    private void writeObject(ObjectOutputStream out) {
+    }
+
+    private void readObject(ObjectInputStream in) {
+    }
+}

--- a/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStep.java
@@ -1,0 +1,30 @@
+package com.vrondakis.zap.workflow;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.CheckForNull;
+
+public class ConfigurePassiveRulesStep extends Step {
+    private final ConfigurePassiveRulesStepParameters configurePassiveRulesStepParameters;
+
+    @DataBoundConstructor
+    public ConfigurePassiveRulesStep(@CheckForNull String action, @CheckForNull Integer ... ids) {
+        this.configurePassiveRulesStepParameters = new ConfigurePassiveRulesStepParameters(action, ids);
+    }
+
+    @Override
+    public StepExecution start(StepContext context) {
+        return new ConfigurePassiveRulesExecution(context, configurePassiveRulesStepParameters);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends DefaultStepDescriptorImpl<ConfigurePassiveRulesExecution> {
+        public DescriptorImpl() {
+            super(ConfigurePassiveRulesExecution.class, "configurePassiveRules", "Configures the list of passive rules to apply / avoid (https://www.zaproxy.org/docs/alerts/)");
+        }
+    }
+}

--- a/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStepParameters.java
@@ -1,0 +1,23 @@
+package com.vrondakis.zap.workflow;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ConfigurePassiveRulesStepParameters {
+
+    private String action;
+    private List<Integer> ids;
+
+    public ConfigurePassiveRulesStepParameters(String action, Integer ... ids) {
+        this.action = action;
+        this.ids = Arrays.asList(ids);
+    }
+
+    public String getAction() {
+        return this.action;
+    }
+
+    public List<Integer> getIds() {
+        return this.ids;
+    }
+}

--- a/src/test/java/com/vrondakis/zap/ZapDriverStub.java
+++ b/src/test/java/com/vrondakis/zap/ZapDriverStub.java
@@ -8,6 +8,7 @@ import hudson.Launcher;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -24,6 +25,8 @@ public class ZapDriverStub implements ZapDriver {
     private List<String> additionalConfigurations;
 
     boolean zapWasShutdown = false;
+    private List<Integer> passiveRulesIds = new ArrayList<>();
+    private String passiveRulesAction;
 
 
     public ZapDriverStub() {
@@ -91,6 +94,26 @@ public class ZapDriverStub implements ZapDriver {
     @Override
     public void startZapProcess(String zapHome, FilePath ws, Launcher launcher) {
         // do nothing
+    }
+
+    @Override
+    public void enablePassiveScanners(List<Integer> ids) throws ZapExecutionException {
+        passiveRulesIds = ids;
+        passiveRulesAction = "enable";
+    }
+
+    @Override
+    public void disablePassiveScanners(List<Integer> ids) throws ZapExecutionException {
+        passiveRulesIds = ids;
+        passiveRulesAction = "disable";
+    }
+
+    public List<Integer> getPassiveRulesIds() {
+        return passiveRulesIds;
+    }
+
+    public String getPassiveRulesAction() {
+        return passiveRulesAction;
     }
 
     @Override

--- a/src/test/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStepTest.java
+++ b/src/test/java/com/vrondakis/zap/workflow/ConfigurePassiveRulesStepTest.java
@@ -1,0 +1,74 @@
+package com.vrondakis.zap.workflow;
+
+import com.vrondakis.zap.ZapDriverController;
+import com.vrondakis.zap.ZapDriverStub;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+
+public class ConfigurePassiveRulesStepTest extends ZapWorkflow {
+    @Test
+    public void testEnableRules() throws Exception {
+        ZapDriverController.setZapDriverClass(ZapDriverStub.class);
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     configurePassiveRules(action: 'enablePassiveScanners', ids: [1,2])\n"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+        r.assertBuildStatus(Result.SUCCESS, run);
+        Assert.assertEquals(((ZapDriverStub)ZapDriverController.getZapDriver(run)).getPassiveRulesIds(), Arrays.asList(1, 2));
+        Assert.assertEquals(((ZapDriverStub)ZapDriverController.getZapDriver(run)).getPassiveRulesAction(), "enable");
+    }
+
+    @Test
+    public void testDisableRules() throws Exception {
+        ZapDriverController.setZapDriverClass(ZapDriverStub.class);
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     configurePassiveRules(action: 'disablePassiveScanners', ids: [1,2,3])\n"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+        r.assertBuildStatus(Result.SUCCESS, run);
+        Assert.assertEquals(((ZapDriverStub)ZapDriverController.getZapDriver(run)).getPassiveRulesIds(), Arrays.asList(1, 2, 3));
+        Assert.assertEquals(((ZapDriverStub)ZapDriverController.getZapDriver(run)).getPassiveRulesAction(), "disable");
+    }
+
+    @Test
+    public void testWrongActionName() throws Exception {
+        ZapDriverController.setZapDriverClass(ZapDriverStub.class);
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     configurePassiveRules(action: 'wrongName', ids: [1,2])\n"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+        r.assertBuildStatus(Result.FAILURE, run);
+
+    }
+
+    @Test
+    public void testNoArgumentImportUrls() throws Exception {
+        ZapDriverController.setZapDriverClass(ZapDriverStub.class);
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node('slave') {\n"
+                + "     importZapUrls()"
+                + "}"
+        ));
+
+        run = job.scheduleBuild2(0).get();
+        r.assertBuildStatus(Result.FAILURE, run);
+    }
+}


### PR DESCRIPTION


<!-- Please describe your pull request here. -->
This PR add the 'configurePassiveRules' pipeline action so that it's possible to tell ZAP which rules will be used during passive scan. For now, all rules were always checked. Linked to issue #28

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
