### PR TITLE
Add optional context id to RunZapAttack step

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -268,6 +268,11 @@ public class ZapDriverImpl implements ZapDriver {
             arguments.put("userId", Integer.toString(zsp.getUser()));
         }
 
+        if(zsp.getContextId() != 0){
+            System.out.println("zap: Using context ID: " + zsp.getContextId());
+            arguments.put("contextId", Integer.toString(zsp.getContextId()));
+        }
+
         if (zsp.getScanPolicyName() != null && !zsp.getScanPolicyName().isEmpty()) {
             arguments.put("scanPolicyName", zsp.getScanPolicyName());
         }

--- a/src/main/java/com/vrondakis/zap/workflow/RunZapAttackStep.java
+++ b/src/main/java/com/vrondakis/zap/workflow/RunZapAttackStep.java
@@ -18,10 +18,11 @@ public class RunZapAttackStep extends Step {
      * @param scanPolicyName The scan policy name to use when attacking (optional). Make sure to load the policy from a file first
      *                       using loadScanPolicy()
      * @param userId         The ZAP user ID to run the attack with, loaded from the context (optional)
+     * @param contextId      The ZAP context ID to run the attack with (optional)
      */
     @DataBoundConstructor
-    public RunZapAttackStep(String scanPolicyName, int userId) {
-        this.runZapAttackStepParameters = new RunZapAttackStepParameters(scanPolicyName, userId);
+    public RunZapAttackStep(String scanPolicyName, int userId, int contextId) {
+        this.runZapAttackStepParameters = new RunZapAttackStepParameters(scanPolicyName, userId, contextId);
     }
 
     @Override

--- a/src/main/java/com/vrondakis/zap/workflow/RunZapAttackStepParameters.java
+++ b/src/main/java/com/vrondakis/zap/workflow/RunZapAttackStepParameters.java
@@ -3,14 +3,20 @@ package com.vrondakis.zap.workflow;
 public class RunZapAttackStepParameters {
     private String scanPolicyName;
     private int user;
+    private int contextId;
 
-    public RunZapAttackStepParameters(String scanPolicyName, int user) {
+    public RunZapAttackStepParameters(String scanPolicyName, int user, int contextId) {
         this.scanPolicyName = scanPolicyName;
         this.user = user;
+        this.contextId = contextId;
     }
 
     public String getScanPolicyName() {
         return scanPolicyName;
+    }
+
+    public int getContextId() {
+        return contextId;
     }
 
     public int getUser() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

*ZAP binaries version 2.11.0.*

I tried to run a ZAP attack in a Jenkins pipeline with no success. The reason is a missing parameter. My pipeline steps looks like:

```
      steps { 
        git branch: [...]
        dir('Zap') {
          script{
            startZap(host: "zap",  port: 8090,  [...])
            sh "echo \"[...]\" > urls"
            importZapUrls(path: "${WORKSPACE}/Zap/urls")
            runZapAttack(userId: 565, scanPolicyName: "Default Policy") 
          }
        }
      }
```

``runZapAttack`` reports *"failed to start attack"* after calling endpoint *"ascan/action/scanAsUser"* . In ``zap.log`` *"missing parameter"* is reported. After investigation,  it turns out that a parameter called ``contextId`` is missing.

Because ``runZapAttack`` does not have such a parameter and ZAP docs says it is optional, I assumed that this parameter is optional in some situations, but not in mine?

API Doc: https://www.zaproxy.org/docs/api/#ascanactionscanasuser

This pull request adds the optional parameter ``contextId`` to ``runZapAttack``. The following statement is solving my issue. I have only one context in my session, but it's index is 2, not 1 or 0. Maybe the source of this issue?

```
runZapAttack(userId: 565, scanPolicyName: "Default Policy", contextId: 2) 
```

I'm not a Java developer and I did just enough changes to get it working for me. Currently I have not a lot time to teach me how to write tests for this project. So I only want to share my "hotfix". Maybe someone can pickup from here. Maybe in 2022 Q1 I can get into it further.

Best Regards
Elia

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
