### PR TITLE
Fix scan id extraction from scanAsUser response

### DIFF
--- a/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
+++ b/src/main/java/com/vrondakis/zap/ZapDriverImpl.java
@@ -53,6 +53,7 @@ public class ZapDriverImpl implements ZapDriver {
 
             apiUrl = "/JSON/" + apiUrl;
             URI uri = new URI("http", null, getZapHost(), getZapPort(), apiUrl, query, null);
+            System.out.println("zap: Calling " + uri.toString());
 
             InputStream response = Unirest.get(uri.toString()).asString().getRawBody();
 
@@ -258,13 +259,13 @@ public class ZapDriverImpl implements ZapDriver {
         }
 
         // Start the scan on a particular site with a particular user
-        String attackUrl = "ascan/action/scan";
+        String endpoint = "scan";
         Map<String, String> arguments = new HashMap<>();
         arguments.put("url", url);
 
         if (zsp.getUser() != 0) {
             System.out.println("zap: Loading user ID: " + zsp.getUser());
-            attackUrl += "AsUser";
+            endpoint = "scanAsUser";
             arguments.put("userId", Integer.toString(zsp.getUser()));
         }
 
@@ -272,8 +273,9 @@ public class ZapDriverImpl implements ZapDriver {
             arguments.put("scanPolicyName", zsp.getScanPolicyName());
         }
 
-        JSONObject result = zapApi(attackUrl, arguments);
-        int zapScanId = result.getInt("scan");
+        JSONObject result = zapApi("ascan/action/"+endpoint, arguments);
+        System.out.println("zap: Scan ID: " + result.getString(endpoint));
+        int zapScanId = result.getInt(endpoint);
         startedScans.add(zapScanId);
 
         return true;


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

*ZAP binaries version 2.11.0.*

I tried to run a ZAP attack in a Jenkins pipeline with no success. The reason is a wrong response data extraction. My pipeline steps looks like:

```
      steps { 
        git branch: [...]
        dir('Zap') {
          script{
            startZap(host: "zap",  port: 8090,  [...])
            sh "echo \"[...]\" > urls"
            importZapUrls(path: "${WORKSPACE}/Zap/urls")
            runZapAttack(userId: 565, scanPolicyName: "Default Policy", contextId: 2) 
          }
        }
      }
```

``runZapAttack`` reports *"failed to start attack"* after calling endpoint *"ascan/action/scanAsUser"* . After investigation,  it turns out that the request was successful, but the response was not expected by the plugin.

If *"ascan/action/scan"* is called, the response body looks like this:

```json
{
  "scan": "{integer scan id}"
}
```

If *"ascan/action/scanAsUser"* is called, the response body looks like this:

```json
{
  "scanAsUser": "{integer scan id}"
}
```

In both cases, the plugin expects the property ``scan``.

This fix expects the property ``scan`` in case of *"ascan/action/scan"* and ``scanAsUser`` in case of *"ascan/action/scanAsUser"*.

I'm not a Java developer and I did just enough changes to get it working for me. Currently I have not a lot time to teach me how to write tests for this project. So I only want to share my "hotfix". Maybe someone can pickup from here. Maybe in 2022 Q1 I can get into it further.

Best Regards
Elia

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
