### PR TITLE
Non blocking ArchiveStepExecution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/*
 *.iws
 *.iml
 *.ipr
+/target/

--- a/src/main/java/com/vrondakis/zap/ZapExecutionException.java
+++ b/src/main/java/com/vrondakis/zap/ZapExecutionException.java
@@ -4,7 +4,6 @@ package com.vrondakis.zap;
 import java.io.PrintStream;
 
 public class ZapExecutionException extends Exception {
-    private boolean listener;
 
     public ZapExecutionException(String message) {
         super(message);

--- a/src/main/java/com/vrondakis/zap/workflow/DefaultStepExecutionImpl.java
+++ b/src/main/java/com/vrondakis/zap/workflow/DefaultStepExecutionImpl.java
@@ -15,12 +15,11 @@ import hudson.model.TaskListener;
 import javax.annotation.Nonnull;
 
 public abstract class DefaultStepExecutionImpl extends AbstractStepExecutionImpl {
-    Run run;
+    Run<?, ?> run;
     Node node;
     FilePath workspace;
     Launcher launcher;
     TaskListener listener;
-    Job<?, ?> job;
 
     DefaultStepExecutionImpl(StepContext context) {
         super(context);
@@ -30,7 +29,6 @@ public abstract class DefaultStepExecutionImpl extends AbstractStepExecutionImpl
             this.launcher = context.get(Launcher.class);
             this.workspace = context.get(FilePath.class);
             this.listener = context.get(TaskListener.class);
-            this.job = context.get(Job.class);
         } catch (IOException | InterruptedException e) {
             this.listener.getLogger().println("zap: Failed to run: " + e.getClass());
             getContext().onFailure(e);


### PR DESCRIPTION
When scanning big applications the ArchiveZapStep may take some time. Currently the step is blocking and will be terminated after 5 minutes. This results in failing jobs with an InterruptedException. Aftern reading this [discussion](https://groups.google.com/g/jenkinsci-dev/c/ojxDProzJAs) and some other resources I made the ArchiveZapStep non blocking using the SynchronousNonBlockingStepExecution. 

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
